### PR TITLE
Reducing scp to be applied at org

### DIFF
--- a/terraform/svc_control_policies.tf
+++ b/terraform/svc_control_policies.tf
@@ -1,13 +1,13 @@
-resource "aws_organizations_policy" "bcca" {
-  name = "Block CloudTrail Configuration Actions"
+resource "aws_organizations_policy" "deny_list" {
+  name = "Deny actions"
 
   content = <<CONTENT
 {
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "Stmt1234567890123",
-            "Effect": "Deny",
+            "Sid": "",
+            "Effect": "DenyConfigChanges",
             "Action": [
                 "cloudtrail:AddTags",
                 "cloudtrail:CreateTrail",
@@ -15,57 +15,18 @@ resource "aws_organizations_policy" "bcca" {
                 "cloudtrail:RemoveTags",
                 "cloudtrail:StartLogging",
                 "cloudtrail:StopLogging",
-                "cloudtrail:UpdateTrail"
+                "cloudtrail:UpdateTrail",
+                "config:DeleteConfigRule",
+                "config:DeleteConfigurationRecorder",
+                "config:DeleteDeliveryChannel",
+                "config:StopConfigurationRecorder"
             ],
             "Resource": [
                 "*"
             ]
-        }
-    ]
-}
-CONTENT
-}
-
-resource "aws_organizations_policy_attachment" "bcca" {
-  policy_id = aws_organizations_policy.bcca.id
-  target_id = aws_organizations_organization.root.roots[0].id
-}
-
-resource "aws_organizations_policy" "bca" {
-  name = "Block AWS Config Actions"
-
-  content = <<CONTENT
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Deny",
-      "Action": [
-        "config:DeleteConfigRule",
-        "config:DeleteConfigurationRecorder",
-        "config:DeleteDeliveryChannel",
-        "config:StopConfigurationRecorder"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-CONTENT
-}
-
-resource "aws_organizations_policy_attachment" "bca" {
-  policy_id = aws_organizations_policy.bca.id
-  target_id = aws_organizations_organization.root.roots[0].id
-}
-
-resource "aws_organizations_policy" "pesr" {
-  name = "Preventing External Sharing of Resources"
-
-  content = <<CONTENT
-{
-    "Version": "2012-10-17",
-    "Statement": [
+        },
         {
+            "Sid": "DenyExternalSharing",
             "Effect": "Deny",
             "Action": [
                 "ram:CreateResourceShare",
@@ -77,73 +38,7 @@ resource "aws_organizations_policy" "pesr" {
                     "ram:RequestedAllowsExternalPrincipals": "true"
                 }
             }
-        }
-    ]
-}
-CONTENT
-}
-
-resource "aws_organizations_policy_attachment" "root" {
-  policy_id = aws_organizations_policy.pesr.id
-  target_id = aws_organizations_organization.root.roots[0].id
-}
-
-resource "aws_organizations_policy" "tmp" {
-  name = "Tag Management Policy"
-
-  content = <<CONTENT
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "ManageTagPolicies",
-            "Effect": "Allow",
-            "Action": [
-                "organizations:ListPoliciesForTarget",
-                "organizations:ListTargetsForPolicy",
-                "organizations:DescribeEffectivePolicy",
-                "organizations:DescribePolicy",
-                "organizations:ListRoots",
-                "organizations:DisableAWSServiceAccess",
-                "organizations:DetachPolicy",
-                "organizations:DeletePolicy",
-                "organizations:DescribeAccount",
-                "organizations:DisablePolicyType",
-                "organizations:ListAWSServiceAccessForOrganization",
-                "organizations:ListPolicies",
-                "organizations:ListAccountsForParent",
-                "organizations:ListAccounts",
-                "organizations:EnableAWSServiceAccess",
-                "organizations:ListCreateAccountStatus",
-                "organizations:DescribeOrganization",
-                "organizations:UpdatePolicy",
-                "organizations:EnablePolicyType",
-                "organizations:DescribeOrganizationalUnit",
-                "organizations:AttachPolicy",
-                "organizations:ListParents",
-                "organizations:ListOrganizationalUnitsForParent",
-                "organizations:CreatePolicy",
-                "organizations:DescribeCreateAccountStatus"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-CONTENT
-}
-
-resource "aws_organizations_policy_attachment" "tmp" {
-  policy_id = aws_organizations_policy.tmp.id
-  target_id = aws_organizations_organization.root.roots[0].id
-}
-
-resource "aws_organizations_policy" "dsous" {
-  name = "Deny Services Outside US"
-
-  content = <<CONTENT
-{
-    "Version": "2012-10-17",
-    "Statement": [
+        },
         {
             "Sid": "DenyAllOutsideUS",
             "Effect": "Deny",
@@ -206,7 +101,56 @@ resource "aws_organizations_policy" "dsous" {
 CONTENT
 }
 
-resource "aws_organizations_policy_attachment" "dsous" {
-  policy_id = aws_organizations_policy.dsous.id
+resource "aws_organizations_policy_attachment" "deny_list" {
+  policy_id = aws_organizations_policy.deny_list.id
+  target_id = aws_organizations_organization.root.roots[0].id
+}
+
+resource "aws_organizations_policy" "allow_list" {
+  name = "Allow actions"
+
+  content = <<CONTENT
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ManageTagPolicies",
+            "Effect": "Allow",
+            "Action": [
+                "organizations:ListPoliciesForTarget",
+                "organizations:ListTargetsForPolicy",
+                "organizations:DescribeEffectivePolicy",
+                "organizations:DescribePolicy",
+                "organizations:ListRoots",
+                "organizations:DisableAWSServiceAccess",
+                "organizations:DetachPolicy",
+                "organizations:DeletePolicy",
+                "organizations:DescribeAccount",
+                "organizations:DisablePolicyType",
+                "organizations:ListAWSServiceAccessForOrganization",
+                "organizations:ListPolicies",
+                "organizations:ListAccountsForParent",
+                "organizations:ListAccounts",
+                "organizations:EnableAWSServiceAccess",
+                "organizations:ListCreateAccountStatus",
+                "organizations:DescribeOrganization",
+                "organizations:UpdatePolicy",
+                "organizations:EnablePolicyType",
+                "organizations:DescribeOrganizationalUnit",
+                "organizations:AttachPolicy",
+                "organizations:ListParents",
+                "organizations:ListOrganizationalUnitsForParent",
+                "organizations:CreatePolicy",
+                "organizations:DescribeCreateAccountStatus"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+CONTENT
+}
+
+resource "aws_organizations_policy_attachment" "allow_list" {
+  policy_id = aws_organizations_policy.allow_list.id
   target_id = aws_organizations_organization.root.roots[0].id
 }


### PR DESCRIPTION
There is a max number of policies that can be appliend:
MAX_POLICY_TYPE_ATTACHMENT_LIMIT_EXCEEDED
https://docs.aws.amazon.com/organizations/latest/APIReference/API_AttachPolicy.html

So the solution was to follow the allow/deny strategy
https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps_strategies.html